### PR TITLE
don't give players multiple custom roles during spawnwave

### DIFF
--- a/SimpleCustomRoles/Handler/PlayerHandler.cs
+++ b/SimpleCustomRoles/Handler/PlayerHandler.cs
@@ -155,7 +155,9 @@ public class PlayerHandler : CustomEventsHandler
         {
             if (item.Wave.SkipCheck || item.Wave.MinRequired > ev.Players.Count)
                 continue;
-            var list = ev.Players.Where(x => x.Role == item.ReplaceRole).ToList();
+            var list = ev.Players.Where(
+                x => x.Role == item.ReplaceRole && !CustomRoleHelpers.TryGetCustomRole(x, out _)
+            ).ToList();
             if (list.Count == 0)
                 continue;
             CustomRoleHelpers.SetCustomInfoToPlayer(list.RandomItem(), item);


### PR DESCRIPTION
certified goob moment?

players can (attempt) to be given multiple custom roles during a spawnwave, this visibly does nothing but it prevents custom roles from spawning if you get unlucky and like 5 get given to the same person (they'll only get the first one obvi)