### PR TITLE
fix escape sometimes erroring

### DIFF
--- a/SimpleCustomRoles/Handler/PlayerHandler.cs
+++ b/SimpleCustomRoles/Handler/PlayerHandler.cs
@@ -16,10 +16,10 @@ public class PlayerHandler : CustomEventsHandler
     {
         if (ev.Player == null)
             return;
-        EscapeHandler.PlayerEscaped.Remove(ev.Player);
+        bool changedRoleFromEscape = EscapeHandler.PlayerEscaped.Remove(ev.Player);
         if (ev.ChangeReason is not PlayerRoles.RoleChangeReason.Destroyed)
             ev.Player.ClearBroadcasts();
-        if (ev.ChangeReason is not PlayerRoles.RoleChangeReason.None)
+        if (!changedRoleFromEscape && ev.ChangeReason is not PlayerRoles.RoleChangeReason.None)
             CustomRoleHelpers.UnSetCustomInfoToPlayer(ev.Player, false);
     }
 


### PR DESCRIPTION
There is a rare bug with escaping into a custom role that causes CustomRoleInfoStorage to sometimes be erroneously called twice.
Listening for Role being set to null via a property, and logging a stack trace when that happens, a bad log (where you get an error) looks like the following:
[badlog.txt](https://github.com/user-attachments/files/28199186/badlog.txt)
Reset is called from two places here, instead of only once.
Repro: Spawn 20 dummies, set them all to some class D role that escapes into a custom chaos role (I used ClassD_Hoarder).
One by one, TP these dummies to escape. Eventually the error will occur. (note that tping multiple simultaneously does NOT make the bug more likely to occur)

A good log (everything works) looks like the following:
[goodlog.txt](https://github.com/user-attachments/files/28199191/goodlog.txt)

Ideally only the first Reset is called when a player escapes, and that is what this achieves (by not calling UnsetCustomInfoToPlayer when that player is being removed from PlayerEscaped).

